### PR TITLE
EDIT iUcto.php - getCustomerList()

### DIFF
--- a/src/IUcto.php
+++ b/src/IUcto.php
@@ -409,6 +409,9 @@ class IUcto
         }
         $rawData = $this->handleRequest('customer', Connector::GET, $filters);
         $paginator = new Paginator($rawData['page'], $rawData['pageCount'], $rawData['pageSize']);
+        if(!isset($rawData['customer'])){
+            $rawData['customer'] = [];
+        }
         return new CustomerList($paginator, $rawData['customer']);
     }
 


### PR DESCRIPTION
Při využití filtrů jsem narazil na problém, kdy se snažím vyfiltrovat neexistující kontakt (customer). $rawData potom následně neobsahují index 'customer' který je nezbytný jako poslední parametr v return CustomerList(). 
Vyřešil jsem tímto způsobem u sebe, aby mi filtrace fungovala rovnou. Budu rád za začlenění do dev-master :)
Případně pokud je na to už jinde lepší způsob tak si nechám rád poradit, ale bez tohoto nemám možnost filtrovat.